### PR TITLE
Set empty base to allow request rewrites

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: ''
 })


### PR DESCRIPTION
Set empty base to allow access lango behind a reverse proxy with a path rewrite. E.g. access it from https://example.com/lango. 

If base is not set, all assets will be loaded from /assets. With empty base set, they will be loaded from assets (without a /).